### PR TITLE
Fixed RBruteForceComp.check()

### DIFF
--- a/src/Controller/Component/RBruteForceComponent.php
+++ b/src/Controller/Component/RBruteForceComponent.php
@@ -51,7 +51,7 @@ class RBruteForceComponent extends Component
         if ($this->options['attemptLog'] == 'all' ||
             ($this->options['attemptLog'] == 'beforeBan' && !$this->isBanned)) {
             $attempt = ['ip' => $this->controller->request->env('REMOTE_ADDR'),
-                'url' => $this->controller->request->url,
+                'url' => $this->controller->request->getPath(),
                 'expire' => strtotime('+' . $this->options['expire']),
             ];
             $attempt = $this->RBruteForce->newEntity($attempt);


### PR DESCRIPTION
When the check attempt takes place on the home page the URL was preventing an RBruteForce DB record from being created (URL is required, but was getting blank).  Using getPath() will provide a "/" which fixes the issue.